### PR TITLE
[Feat] Item 포획 관련 로직 수정 및 Item, Player 이동, Bubble 충돌 관련 로직 수정

### DIFF
--- a/Assets/Prefabs/[Test] Items/Item.prefab
+++ b/Assets/Prefabs/[Test] Items/Item.prefab
@@ -130,6 +130,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b6142f4f8ea9f614fa1639beb73eb81c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _itemData: {fileID: 11400000, guid: e369b7ccaa1d399488bbd3780b9578d8, type: 2}
 --- !u!54 &8183217591889662305
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -139,7 +140,7 @@ Rigidbody:
   m_GameObject: {fileID: 3306776358836982081}
   serializedVersion: 4
   m_Mass: 1
-  m_Drag: 0
+  m_Drag: 1
   m_AngularDrag: 0.05
   m_CenterOfMass: {x: 0, y: 0, z: 0}
   m_InertiaTensor: {x: 1, y: 1, z: 1}
@@ -155,7 +156,7 @@ Rigidbody:
   m_UseGravity: 1
   m_IsKinematic: 0
   m_Interpolate: 0
-  m_Constraints: 0
+  m_Constraints: 80
   m_CollisionDetection: 0
 --- !u!65 &6313176139201401987
 BoxCollider:

--- a/Assets/Scenes/GameLogic.unity
+++ b/Assets/Scenes/GameLogic.unity
@@ -1520,7 +1520,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &783236846
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/GameLogic.unity
+++ b/Assets/Scenes/GameLogic.unity
@@ -138,6 +138,10 @@ PrefabInstance:
       propertyPath: m_Layer
       value: 11
       objectReference: {fileID: 0}
+    - target: {fileID: 1978775886026106, guid: bbc12ae2f967ec04e8c3c39eeb92733b, type: 3}
+      propertyPath: m_TagString
+      value: Background
+      objectReference: {fileID: 0}
     - target: {fileID: 4962039562683002, guid: bbc12ae2f967ec04e8c3c39eeb92733b, type: 3}
       propertyPath: m_RootOrder
       value: 318
@@ -248,89 +252,6 @@ Transform:
   - {fileID: 130209970}
   m_Father: {fileID: 1174084213}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &31786596
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 31786601}
-  - component: {fileID: 31786600}
-  - component: {fileID: 31786599}
-  m_Layer: 0
-  m_Name: Cube (1)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!23 &31786599
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 31786596}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &31786600
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 31786596}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &31786601
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 31786596}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.25, z: 0}
-  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1288317392}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &45438325
 GameObject:
   m_ObjectHideFlags: 0
@@ -344,7 +265,7 @@ GameObject:
   - component: {fileID: 45438327}
   m_Layer: 0
   m_Name: Stairs
-  m_TagString: Untagged
+  m_TagString: Background
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -432,6 +353,10 @@ PrefabInstance:
     - target: {fileID: 1978775886026106, guid: bbc12ae2f967ec04e8c3c39eeb92733b, type: 3}
       propertyPath: m_Layer
       value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 1978775886026106, guid: bbc12ae2f967ec04e8c3c39eeb92733b, type: 3}
+      propertyPath: m_TagString
+      value: Background
       objectReference: {fileID: 0}
     - target: {fileID: 4962039562683002, guid: bbc12ae2f967ec04e8c3c39eeb92733b, type: 3}
       propertyPath: m_RootOrder
@@ -544,6 +469,10 @@ PrefabInstance:
       propertyPath: m_Layer
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1109385109949186, guid: 37e681eb08549004c9d9c2be529cbf54, type: 3}
+      propertyPath: m_TagString
+      value: Background
+      objectReference: {fileID: 0}
     - target: {fileID: 4812002822647660, guid: 37e681eb08549004c9d9c2be529cbf54, type: 3}
       propertyPath: m_RootOrder
       value: 57
@@ -601,7 +530,7 @@ GameObject:
   - component: {fileID: 226791645}
   m_Layer: 0
   m_Name: Wall (3)
-  m_TagString: Untagged
+  m_TagString: Background
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -706,7 +635,7 @@ GameObject:
   - component: {fileID: 255789880}
   m_Layer: 11
   m_Name: Plane
-  m_TagString: Untagged
+  m_TagString: Background
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -813,6 +742,10 @@ PrefabInstance:
     - target: {fileID: 1978775886026106, guid: bbc12ae2f967ec04e8c3c39eeb92733b, type: 3}
       propertyPath: m_Layer
       value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 1978775886026106, guid: bbc12ae2f967ec04e8c3c39eeb92733b, type: 3}
+      propertyPath: m_TagString
+      value: Background
       objectReference: {fileID: 0}
     - target: {fileID: 4962039562683002, guid: bbc12ae2f967ec04e8c3c39eeb92733b, type: 3}
       propertyPath: m_RootOrder
@@ -942,7 +875,7 @@ GameObject:
   - component: {fileID: 523543874}
   m_Layer: 0
   m_Name: Wall
-  m_TagString: Untagged
+  m_TagString: Background
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1221,6 +1154,10 @@ PrefabInstance:
       propertyPath: m_Layer
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1118085362977378, guid: 5527826a6315a224d850675a730c4f62, type: 3}
+      propertyPath: m_TagString
+      value: Background
+      objectReference: {fileID: 0}
     - target: {fileID: 4035765028099436, guid: 5527826a6315a224d850675a730c4f62, type: 3}
       propertyPath: m_RootOrder
       value: 172
@@ -1284,6 +1221,10 @@ PrefabInstance:
     - target: {fileID: 1235894906759354, guid: f675c07d915406144ae3100b985c0abc, type: 3}
       propertyPath: m_Layer
       value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 1235894906759354, guid: f675c07d915406144ae3100b985c0abc, type: 3}
+      propertyPath: m_TagString
+      value: Background
       objectReference: {fileID: 0}
     - target: {fileID: 4186415992352112, guid: f675c07d915406144ae3100b985c0abc, type: 3}
       propertyPath: m_RootOrder
@@ -1440,6 +1381,10 @@ PrefabInstance:
       propertyPath: m_Layer
       value: 11
       objectReference: {fileID: 0}
+    - target: {fileID: 1978775886026106, guid: bbc12ae2f967ec04e8c3c39eeb92733b, type: 3}
+      propertyPath: m_TagString
+      value: Background
+      objectReference: {fileID: 0}
     - target: {fileID: 4962039562683002, guid: bbc12ae2f967ec04e8c3c39eeb92733b, type: 3}
       propertyPath: m_RootOrder
       value: 313
@@ -1520,7 +1465,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &783236846
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1535,8 +1480,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _items:
   - {fileID: 3306776358836982081, guid: 881a8f1a1e15a0b47ad813669d5725c9, type: 3}
-  _spawnMaxTime: 3
-  _spawnMinTime: 5
+  _spawnMaxTime: 1
+  _spawnMinTime: 3
   _minBackgroundSize: {x: -20, y: -20}
   _maxBackgroundSize: {x: 20, y: 20}
   _itemDistance: 5
@@ -1570,6 +1515,10 @@ PrefabInstance:
     - target: {fileID: 1978775886026106, guid: bbc12ae2f967ec04e8c3c39eeb92733b, type: 3}
       propertyPath: m_Layer
       value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 1978775886026106, guid: bbc12ae2f967ec04e8c3c39eeb92733b, type: 3}
+      propertyPath: m_TagString
+      value: Background
       objectReference: {fileID: 0}
     - target: {fileID: 4962039562683002, guid: bbc12ae2f967ec04e8c3c39eeb92733b, type: 3}
       propertyPath: m_RootOrder
@@ -1651,6 +1600,10 @@ PrefabInstance:
       propertyPath: m_Layer
       value: 11
       objectReference: {fileID: 0}
+    - target: {fileID: 1765673748168840, guid: fc6f3424666dfda45bcbadbbf42e5968, type: 3}
+      propertyPath: m_TagString
+      value: Background
+      objectReference: {fileID: 0}
     - target: {fileID: 4003804723947526, guid: fc6f3424666dfda45bcbadbbf42e5968, type: 3}
       propertyPath: m_RootOrder
       value: 271
@@ -1731,6 +1684,10 @@ PrefabInstance:
       propertyPath: m_Layer
       value: 11
       objectReference: {fileID: 0}
+    - target: {fileID: 1978775886026106, guid: bbc12ae2f967ec04e8c3c39eeb92733b, type: 3}
+      propertyPath: m_TagString
+      value: Background
+      objectReference: {fileID: 0}
     - target: {fileID: 4962039562683002, guid: bbc12ae2f967ec04e8c3c39eeb92733b, type: 3}
       propertyPath: m_RootOrder
       value: 269
@@ -1800,7 +1757,7 @@ GameObject:
   - component: {fileID: 1002242418}
   m_Layer: 0
   m_Name: Wall (1)
-  m_TagString: Untagged
+  m_TagString: Background
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1907,6 +1864,10 @@ PrefabInstance:
       propertyPath: m_Layer
       value: 11
       objectReference: {fileID: 0}
+    - target: {fileID: 1235894906759354, guid: f675c07d915406144ae3100b985c0abc, type: 3}
+      propertyPath: m_TagString
+      value: Background
+      objectReference: {fileID: 0}
     - target: {fileID: 4186415992352112, guid: f675c07d915406144ae3100b985c0abc, type: 3}
       propertyPath: m_RootOrder
       value: 320
@@ -1978,6 +1939,10 @@ PrefabInstance:
     - target: {fileID: 1765673748168840, guid: fc6f3424666dfda45bcbadbbf42e5968, type: 3}
       propertyPath: m_Layer
       value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 1765673748168840, guid: fc6f3424666dfda45bcbadbbf42e5968, type: 3}
+      propertyPath: m_TagString
+      value: Background
       objectReference: {fileID: 0}
     - target: {fileID: 4003804723947526, guid: fc6f3424666dfda45bcbadbbf42e5968, type: 3}
       propertyPath: m_RootOrder
@@ -2053,6 +2018,10 @@ PrefabInstance:
     - target: {fileID: 1978775886026106, guid: bbc12ae2f967ec04e8c3c39eeb92733b, type: 3}
       propertyPath: m_Layer
       value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 1978775886026106, guid: bbc12ae2f967ec04e8c3c39eeb92733b, type: 3}
+      propertyPath: m_TagString
+      value: Background
       objectReference: {fileID: 0}
     - target: {fileID: 4962039562683002, guid: bbc12ae2f967ec04e8c3c39eeb92733b, type: 3}
       propertyPath: m_RootOrder
@@ -2227,7 +2196,7 @@ Rigidbody:
   m_GameObject: {fileID: 1174084205}
   serializedVersion: 4
   m_Mass: 20
-  m_Drag: 0
+  m_Drag: 1
   m_AngularDrag: 0.05
   m_CenterOfMass: {x: 0, y: 0, z: 0}
   m_InertiaTensor: {x: 1, y: 1, z: 1}
@@ -2330,6 +2299,10 @@ PrefabInstance:
       propertyPath: m_Layer
       value: 11
       objectReference: {fileID: 0}
+    - target: {fileID: 1235894906759354, guid: f675c07d915406144ae3100b985c0abc, type: 3}
+      propertyPath: m_TagString
+      value: Background
+      objectReference: {fileID: 0}
     - target: {fileID: 4186415992352112, guid: f675c07d915406144ae3100b985c0abc, type: 3}
       propertyPath: m_RootOrder
       value: 312
@@ -2402,6 +2375,10 @@ PrefabInstance:
       propertyPath: m_Layer
       value: 11
       objectReference: {fileID: 0}
+    - target: {fileID: 1235894906759354, guid: f675c07d915406144ae3100b985c0abc, type: 3}
+      propertyPath: m_TagString
+      value: Background
+      objectReference: {fileID: 0}
     - target: {fileID: 4186415992352112, guid: f675c07d915406144ae3100b985c0abc, type: 3}
       propertyPath: m_RootOrder
       value: 311
@@ -2473,6 +2450,10 @@ PrefabInstance:
     - target: {fileID: 1235894906759354, guid: f675c07d915406144ae3100b985c0abc, type: 3}
       propertyPath: m_Layer
       value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 1235894906759354, guid: f675c07d915406144ae3100b985c0abc, type: 3}
+      propertyPath: m_TagString
+      value: Background
       objectReference: {fileID: 0}
     - target: {fileID: 4186415992352112, guid: f675c07d915406144ae3100b985c0abc, type: 3}
       propertyPath: m_RootOrder
@@ -2668,6 +2649,10 @@ PrefabInstance:
       propertyPath: m_Layer
       value: 11
       objectReference: {fileID: 0}
+    - target: {fileID: 1235894906759354, guid: f675c07d915406144ae3100b985c0abc, type: 3}
+      propertyPath: m_TagString
+      value: Background
+      objectReference: {fileID: 0}
     - target: {fileID: 4186415992352112, guid: f675c07d915406144ae3100b985c0abc, type: 3}
       propertyPath: m_RootOrder
       value: 304
@@ -2720,101 +2705,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1253040215}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1288317391
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1288317392}
-  - component: {fileID: 1288317395}
-  - component: {fileID: 1288317394}
-  - component: {fileID: 1288317393}
-  m_Layer: 10
-  m_Name: GameObject
-  m_TagString: Item
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1288317392
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1288317391}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 5}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 31786601}
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!65 &1288317393
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1288317391}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 0.5, y: 0.5, z: 0.5}
-  m_Center: {x: 0, y: 0.25, z: 0}
---- !u!54 &1288317394
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1288317391}
-  serializedVersion: 4
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_CenterOfMass: {x: 0, y: 0, z: 0}
-  m_InertiaTensor: {x: 1, y: 1, z: 1}
-  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ImplicitCom: 1
-  m_ImplicitTensor: 1
-  m_UseGravity: 1
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 0
---- !u!114 &1288317395
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1288317391}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b6142f4f8ea9f614fa1639beb73eb81c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1368855200
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2830,6 +2720,10 @@ PrefabInstance:
     - target: {fileID: 1235894906759354, guid: f675c07d915406144ae3100b985c0abc, type: 3}
       propertyPath: m_Layer
       value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 1235894906759354, guid: f675c07d915406144ae3100b985c0abc, type: 3}
+      propertyPath: m_TagString
+      value: Background
       objectReference: {fileID: 0}
     - target: {fileID: 4186415992352112, guid: f675c07d915406144ae3100b985c0abc, type: 3}
       propertyPath: m_RootOrder
@@ -3017,6 +2911,10 @@ PrefabInstance:
       propertyPath: m_Layer
       value: 11
       objectReference: {fileID: 0}
+    - target: {fileID: 1235894906759354, guid: f675c07d915406144ae3100b985c0abc, type: 3}
+      propertyPath: m_TagString
+      value: Background
+      objectReference: {fileID: 0}
     - target: {fileID: 4186415992352112, guid: f675c07d915406144ae3100b985c0abc, type: 3}
       propertyPath: m_RootOrder
       value: 319
@@ -3117,7 +3015,7 @@ GameObject:
   - component: {fileID: 1524743233}
   m_Layer: 0
   m_Name: Slope
-  m_TagString: Untagged
+  m_TagString: Background
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -3175,6 +3073,10 @@ PrefabInstance:
     - target: {fileID: 1118085362977378, guid: 5527826a6315a224d850675a730c4f62, type: 3}
       propertyPath: m_Layer
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1118085362977378, guid: 5527826a6315a224d850675a730c4f62, type: 3}
+      propertyPath: m_TagString
+      value: Background
       objectReference: {fileID: 0}
     - target: {fileID: 4035765028099436, guid: 5527826a6315a224d850675a730c4f62, type: 3}
       propertyPath: m_RootOrder
@@ -3425,6 +3327,10 @@ PrefabInstance:
     - target: {fileID: 1765673748168840, guid: fc6f3424666dfda45bcbadbbf42e5968, type: 3}
       propertyPath: m_Layer
       value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 1765673748168840, guid: fc6f3424666dfda45bcbadbbf42e5968, type: 3}
+      propertyPath: m_TagString
+      value: Background
       objectReference: {fileID: 0}
     - target: {fileID: 4003804723947526, guid: fc6f3424666dfda45bcbadbbf42e5968, type: 3}
       propertyPath: m_RootOrder
@@ -3734,7 +3640,7 @@ Rigidbody:
   m_GameObject: {fileID: 1732032768}
   serializedVersion: 4
   m_Mass: 20
-  m_Drag: 0
+  m_Drag: 1
   m_AngularDrag: 0.05
   m_CenterOfMass: {x: 0, y: 0, z: 0}
   m_InertiaTensor: {x: 1, y: 1, z: 1}
@@ -3802,7 +3708,7 @@ GameObject:
   - component: {fileID: 1830345758}
   m_Layer: 0
   m_Name: Wall (2)
-  m_TagString: Untagged
+  m_TagString: Background
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -3981,6 +3887,10 @@ PrefabInstance:
       propertyPath: m_Layer
       value: 11
       objectReference: {fileID: 0}
+    - target: {fileID: 1978775886026106, guid: bbc12ae2f967ec04e8c3c39eeb92733b, type: 3}
+      propertyPath: m_TagString
+      value: Background
+      objectReference: {fileID: 0}
     - target: {fileID: 4962039562683002, guid: bbc12ae2f967ec04e8c3c39eeb92733b, type: 3}
       propertyPath: m_RootOrder
       value: 315
@@ -4057,6 +3967,10 @@ PrefabInstance:
       propertyPath: m_Layer
       value: 11
       objectReference: {fileID: 0}
+    - target: {fileID: 1978775886026106, guid: bbc12ae2f967ec04e8c3c39eeb92733b, type: 3}
+      propertyPath: m_TagString
+      value: Background
+      objectReference: {fileID: 0}
     - target: {fileID: 4962039562683002, guid: bbc12ae2f967ec04e8c3c39eeb92733b, type: 3}
       propertyPath: m_RootOrder
       value: 306
@@ -4131,7 +4045,7 @@ GameObject:
   - component: {fileID: 2045942780}
   m_Layer: 0
   m_Name: Cube (1)
-  m_TagString: Untagged
+  m_TagString: Background
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -4234,7 +4148,7 @@ GameObject:
   - component: {fileID: 2048640715}
   m_Layer: 0
   m_Name: Background
-  m_TagString: Untagged
+  m_TagString: Background
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -4311,6 +4225,10 @@ PrefabInstance:
     - target: {fileID: 1235894906759354, guid: f675c07d915406144ae3100b985c0abc, type: 3}
       propertyPath: m_Layer
       value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 1235894906759354, guid: f675c07d915406144ae3100b985c0abc, type: 3}
+      propertyPath: m_TagString
+      value: Background
       objectReference: {fileID: 0}
     - target: {fileID: 4186415992352112, guid: f675c07d915406144ae3100b985c0abc, type: 3}
       propertyPath: m_RootOrder
@@ -4465,6 +4383,10 @@ PrefabInstance:
       propertyPath: m_Layer
       value: 11
       objectReference: {fileID: 0}
+    - target: {fileID: 1978775886026106, guid: bbc12ae2f967ec04e8c3c39eeb92733b, type: 3}
+      propertyPath: m_TagString
+      value: Background
+      objectReference: {fileID: 0}
     - target: {fileID: 4962039562683002, guid: bbc12ae2f967ec04e8c3c39eeb92733b, type: 3}
       propertyPath: m_RootOrder
       value: 317
@@ -4538,6 +4460,5 @@ SceneRoots:
   - {fileID: 2048640714}
   - {fileID: 1732032769}
   - {fileID: 1174084213}
-  - {fileID: 1288317392}
   - {fileID: 783236847}
   - {fileID: 1731343296}

--- a/Assets/Scripts/Bubble/Bubble.cs
+++ b/Assets/Scripts/Bubble/Bubble.cs
@@ -15,6 +15,8 @@ public class Bubble : MonoBehaviour
     private Coroutine _growBubbleCoroutine;
     private Coroutine _destroyBubbleCoroutine;
 
+    private bool _isItem;
+
     private void Awake()
     {
         _rigidbody = GetComponent<Rigidbody>();
@@ -95,12 +97,15 @@ public class Bubble : MonoBehaviour
         _rigidbody.drag *= _bubbleData.Drag;
 
         //# 일정 시간 후 자동 파괴를 위한 코루틴
-        if (!isItem)
-            _destroyBubbleCoroutine = StartCoroutine(DestroyBubble(_bubbleData.TrappedDestroyDelay));
-        else
+        if (isItem)
         {
+            _isItem = true;
             _rigidbody.useGravity = true;
             _destroyBubbleCoroutine = StartCoroutine(DestroyBubble(_bubbleData.ItemTrappedDestroyDelay));
+        }
+        else
+        {
+            _destroyBubbleCoroutine = StartCoroutine(DestroyBubble(_bubbleData.TrappedDestroyDelay));
         }
     }
 
@@ -166,6 +171,13 @@ public class Bubble : MonoBehaviour
         var playerDirection = (transform.position - other.gameObject.transform.position).normalized;
 
         playerDirection.y = Mathf.Clamp(_rigidbody.velocity.y, -0.05f, 0.05f);
-        _rigidbody.AddForce(playerDirection * _bubbleData.Force, ForceMode.Impulse);
+        _rigidbody.AddForce(playerDirection * _bubbleData.Force / 2, ForceMode.Impulse);
+
+        //# 충격을 받으면 시간 재설정
+        if (_isItem)
+        {
+            StopCoroutine(_destroyBubbleCoroutine);
+            _destroyBubbleCoroutine = StartCoroutine(DestroyBubble(_bubbleData.ItemTrappedDestroyDelay));
+        }
     }
 }

--- a/Assets/Scripts/Bubble/Bubble.cs
+++ b/Assets/Scripts/Bubble/Bubble.cs
@@ -71,7 +71,10 @@ public class Bubble : MonoBehaviour
     {
         //# 기존 endScale off
         StopCoroutine(_growBubbleCoroutine);
+        _growBubbleCoroutine = null;
+
         StopCoroutine(_destroyBubbleCoroutine);
+        _destroyBubbleCoroutine = null;
 
         _collider.enabled = false;
 
@@ -112,7 +115,7 @@ public class Bubble : MonoBehaviour
     private void SetObjectInBubble()
     {
         //# 플레이어가 갖혀있어야 하므로 중력을 끄고 물리 법칙 적용을 받지 않기 위해 kinematic true;
-        _objectInteractable.InBubble();
+        _objectInteractable.TrapInBubble();
 
         //# 버블이 굴러가거나 했을 때, player도 같이 움직여야 하므로 parent에 추가
         _objectTransform.SetParent(transform);
@@ -127,7 +130,7 @@ public class Bubble : MonoBehaviour
 
         if (_objectInteractable != null)
         {
-            _objectInteractable.OutBubble();
+            _objectInteractable.PopBubble();
             _objectInteractable = null;
             _objectTransform = null;
         }
@@ -171,13 +174,20 @@ public class Bubble : MonoBehaviour
         var playerDirection = (transform.position - other.gameObject.transform.position).normalized;
 
         playerDirection.y = Mathf.Clamp(_rigidbody.velocity.y, -0.05f, 0.05f);
-        _rigidbody.AddForce(playerDirection * _bubbleData.Force / 2, ForceMode.Impulse);
+        _rigidbody.AddForce(playerDirection * _bubbleData.Force, ForceMode.Impulse);
 
         //# 충격을 받으면 시간 재설정
-        if (_isItem)
+        if (_isItem && _destroyBubbleCoroutine != null)
         {
             StopCoroutine(_destroyBubbleCoroutine);
-            _destroyBubbleCoroutine = StartCoroutine(DestroyBubble(_bubbleData.ItemTrappedDestroyDelay));
+            _destroyBubbleCoroutine = null;
         }
+    }
+
+    private void OnCollisionExit(Collision other)
+    {
+        if (!other.gameObject.CompareTag("Player")) return;
+
+        _destroyBubbleCoroutine = StartCoroutine(DestroyBubble(_bubbleData.ItemTrappedDestroyDelay));
     }
 }

--- a/Assets/Scripts/Interface/IBubbleInteractable.cs
+++ b/Assets/Scripts/Interface/IBubbleInteractable.cs
@@ -2,6 +2,6 @@ using UnityEngine;
 
 public interface IBubbleInteractable
 {
-    public void InBubble();
-    public void OutBubble();
+    public void TrapInBubble();
+    public void PopBubble();
 }

--- a/Assets/Scripts/Items/Item.cs
+++ b/Assets/Scripts/Items/Item.cs
@@ -4,27 +4,38 @@ using UnityEngine;
 
 public class Item : MonoBehaviour, IBubbleInteractable, ITransformAdjustable
 {
-    private Rigidbody _rigidbody;
+    [SerializeField] private ItemDataSO _itemData;
 
-    //# 추후 Collider 부분과 Collider Enable/Disable하는 부분은 자식 오브젝트에서 override
-    private BoxCollider _collider;
+    private Rigidbody _rigidbody;
+    private Collider _collider;
+
+    private Coroutine _destroyCoroutine;
 
     private void Awake()
     {
         _rigidbody = GetComponent<Rigidbody>();
-        _collider = GetComponent<BoxCollider>();
+        _collider = GetComponent<Collider>();
     }
 
-    public void InBubble()
+    private void OnEnable()
+    {
+        //# 아이템 생성 시 포획이 되지 않는다면 일정 시간 뒤 파괴할 수 있게 Coroutine 시작
+        _destroyCoroutine = StartCoroutine(DestroyItem());
+    }
+
+    public void TrapInBubble()
     {
         //# Item이 갇혀있어야 하므로 중력을 끄고 물리 법칙 적용을 받지 않기 위해 kinematic true;
         _rigidbody.useGravity = false;
         _rigidbody.isKinematic = true;
 
         _collider.enabled = false;
+
+        //# 포획되어 있을 때는 파괴되지 않아야 하기에 Coroutine 중지
+        StopCoroutine(_destroyCoroutine);
     }
 
-    public void OutBubble()
+    public void PopBubble()
     {
         //# 버블이 굴러가거나 했을 때, player도 같이 움직여야 하므로 parent에 추가
         _rigidbody.transform.SetParent(null);
@@ -32,32 +43,27 @@ public class Item : MonoBehaviour, IBubbleInteractable, ITransformAdjustable
         _rigidbody.isKinematic = false;
         _rigidbody.velocity = Vector3.zero;
 
+        //# x, z 축으로 회전되어 물체가 기울어지지 않도록 회전 보정
         transform.rotation = Quaternion.Euler(new Vector3(0f, transform.eulerAngles.y, 0f));
 
         _collider.enabled = true;
+
+        //# Pop이 되었을 때, 다시 일정 시간 뒤 파괴될 수 있게 Coroutine 시작
+        _destroyCoroutine = StartCoroutine(DestroyItem());
     }
 
-    public void SetPosition(Vector3 position)
-    {
-        transform.position = position;
-    }
-
+    public void SetPosition(Vector3 position) => transform.position = position;
     public Vector3 GetPosition() => transform.position;
-
-    public void SetLocalPosition(Vector3 position)
-    {
-        transform.position = position;
-    }
-
+    public void SetLocalPosition(Vector3 position) => transform.localPosition = position;
     public Vector3 GetLocalPosition() => transform.localPosition;
+    public void SetLocalScale(Vector3 localScale) => transform.localScale = localScale;
+    public void SetParent(Transform parent, bool worldPositionStays = true) => transform.SetParent(parent, worldPositionStays);
 
-    public void SetLocalScale(Vector3 localScale)
+    private IEnumerator DestroyItem()
     {
-        transform.localScale = localScale;
-    }
+        yield return _itemData.DestroyDelay;
 
-    public void SetParent(Transform parent, bool worldPositionStays = true)
-    {
-        transform.SetParent(parent, worldPositionStays);
+        ItemManager.Instance.RemoveItem(gameObject);
+        Destroy(gameObject);
     }
 }

--- a/Assets/Scripts/Items/ItemManager.cs
+++ b/Assets/Scripts/Items/ItemManager.cs
@@ -34,6 +34,8 @@ public class ItemManager : MonoBehaviour
     {
         foreach (var item in _items)
         {
+            if (item == null) return true;
+
             if (Vector3.Distance(item.transform.position, newPosition) < distance)
             {
                 return false;

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -17,7 +17,7 @@ public class Player : MonoBehaviour, IBubbleInteractable, ITransformAdjustable
         _collider = GetComponent<CapsuleCollider>();
     }
 
-    public void InBubble()
+    public void TrapInBubble()
     {
         //# 플레이어가 갇혀있어야 하므로 중력을 끄고 물리 법칙 적용을 받지 않기 위해 kinematic true;
         Rigid.useGravity = false;
@@ -28,7 +28,7 @@ public class Player : MonoBehaviour, IBubbleInteractable, ITransformAdjustable
         IsInBubble = true;
     }
 
-    public void OutBubble()
+    public void PopBubble()
     {
         //# 버블이 굴러가거나 했을 때, player도 같이 움직여야 하므로 parent에 추가
         Rigid.transform.SetParent(null);
@@ -43,27 +43,10 @@ public class Player : MonoBehaviour, IBubbleInteractable, ITransformAdjustable
         IsInBubble = false;
     }
 
-    public void SetPosition(Vector3 position)
-    {
-        transform.position = position;
-    }
-
+    public void SetPosition(Vector3 position) => transform.position = position;
     public Vector3 GetPosition() => transform.position;
-
-    public void SetLocalPosition(Vector3 position)
-    {
-        transform.position = position;
-    }
-
+    public void SetLocalPosition(Vector3 position) => transform.localPosition = position;
     public Vector3 GetLocalPosition() => transform.localPosition;
-
-    public void SetLocalScale(Vector3 localScale)
-    {
-        transform.localScale = localScale;
-    }
-
-    public void SetParent(Transform parent, bool worldPositionStays = true)
-    {
-        transform.SetParent(parent, worldPositionStays);
-    }
+    public void SetLocalScale(Vector3 localScale) => transform.localScale = localScale;
+    public void SetParent(Transform parent, bool worldPositionStays = true) => transform.SetParent(parent, worldPositionStays);
 }

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -36,7 +36,7 @@ public class PlayerMovement : MonoBehaviour
     {
         var moveDirection = (_moveInput.y * transform.forward + _moveInput.x * transform.right).normalized;
         moveDirection *= _playerMoveSpeed;
-        moveDirection.y = _player.Rigid.velocity.y;
+        // moveDirection.y = _player.Rigid.velocity.y;
 
         //# velocity로 Player를 움직일 때, 경사나 턱이 있을 경우, 날아가는 현상을 막기 위해 Ground Check
         bool isGrounded =
@@ -46,11 +46,34 @@ public class PlayerMovement : MonoBehaviour
         {
             moveDirection.y = 0f;
         }
+        else
+        {
+            //# 속도에 따라 위로 많이 뜨는 현상을 줄이기 위해 1f로 max는 제한
+            moveDirection.y = Mathf.Clamp(moveDirection.y, float.MinValue, 1f);
+        }
 
-        //# 속도에 따라 위로 많이 뜨는 현상을 줄이기 위해 1f로 max는 제한
-        moveDirection.y = Mathf.Clamp(moveDirection.y, float.MinValue, 1f);
+        var moveOffset = moveDirection * Time.fixedDeltaTime;
 
-        _player.Rigid.velocity = moveDirection;
+        //# 충돌 검사
+        if (_player.Rigid.SweepTest(moveOffset.normalized, out var hit, moveOffset.magnitude))
+        {
+            //# 벽과 충돌했다면 슬라이딩
+            if (hit.collider.CompareTag("Background"))
+            {
+                //# 충돌한 경우, 슬라이딩을 위해 벽에 수직한 방향 제거
+                var slidingDirection = Vector3.ProjectOnPlane(moveOffset, hit.normal).normalized;
+
+                //# 슬라이딩 방향도 검사 후 막혔다면 이동하지 않음
+                if (_player.Rigid.SweepTest(slidingDirection, out var slideHit, moveOffset.magnitude)) return;
+
+                //# 충돌 안 했으면 슬라이딩 방향으로만 이동
+                _player.Rigid.MovePosition(_player.Rigid.position + slidingDirection * moveOffset.magnitude);
+
+                return;
+            }
+        }
+        //# 충돌을 안했거나 벽이 아니라면 원래 방향으로 이동
+        _player.Rigid.MovePosition(_player.Rigid.position + moveOffset);
     }
 
     private void GetMoveInput(Vector2 moveInput)

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -47,6 +47,9 @@ public class PlayerMovement : MonoBehaviour
             moveDirection.y = 0f;
         }
 
+        //# 속도에 따라 위로 많이 뜨는 현상을 줄이기 위해 1f로 max는 제한
+        moveDirection.y = Mathf.Clamp(moveDirection.y, float.MinValue, 1f);
+
         _player.Rigid.velocity = moveDirection;
     }
 

--- a/Assets/Scripts/ScriptableObject/BubbleDataSO.cs
+++ b/Assets/Scripts/ScriptableObject/BubbleDataSO.cs
@@ -8,7 +8,7 @@ public class BubbleDataSO : ScriptableObject
     public float GrowDuration = 1f;
     public WaitForSeconds UnTrappedDestroyDelay = new WaitForSeconds(3f);
     public WaitForSeconds TrappedDestroyDelay = new WaitForSeconds(1f);
-    public WaitForSeconds ItemTrappedDestroyDelay = new WaitForSeconds(5f);
+    public WaitForSeconds ItemTrappedDestroyDelay = new WaitForSeconds(2f);
 
     public float StartScale = 0.1f;
     public float EndScale = 2f;

--- a/Assets/Scripts/ScriptableObject/ItemDataSO.asset
+++ b/Assets/Scripts/ScriptableObject/ItemDataSO.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 46cb049785e205c4793d0ecb231f68ad, type: 3}
+  m_Name: ItemDataSO
+  m_EditorClassIdentifier: 
+  Score: 1

--- a/Assets/Scripts/ScriptableObject/ItemDataSO.asset.meta
+++ b/Assets/Scripts/ScriptableObject/ItemDataSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e369b7ccaa1d399488bbd3780b9578d8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObject/ItemDataSO.cs
+++ b/Assets/Scripts/ScriptableObject/ItemDataSO.cs
@@ -1,0 +1,8 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "ItemDataSO", menuName = "Scriptable Objects/ItemDataSO")]
+public class ItemDataSO : ScriptableObject
+{
+    public int Score = 1;
+    public WaitForSeconds DestroyDelay = new WaitForSeconds(5f);
+}

--- a/Assets/Scripts/ScriptableObject/ItemDataSO.cs.meta
+++ b/Assets/Scripts/ScriptableObject/ItemDataSO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 46cb049785e205c4793d0ecb231f68ad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -80,7 +80,7 @@ PlayerSettings:
   androidPredictiveBackSupport: 0
   defaultIsNativeResolution: 1
   macRetinaSupport: 1
-  runInBackground: 0
+  runInBackground: 1
   captureSingleScreen: 0
   muteOtherAudioSources: 0
   Prepare IOS For Recording: 0

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -5,6 +5,7 @@ TagManager:
   serializedVersion: 2
   tags:
   - Item
+  - Background
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
* 버블로 Item 포획 후 Player와 충돌이 없다면 2초 뒤 Pop
* 버블로 Item 포획 후 Player와 충돌이 있다면 버블의 destroy 시간 초기화
* Item Enable 시 Coroutine을 사용하여 일정 시간 뒤 파괴 구현
* Bubble에 포획 시 해당 Coroutine을 종료하여 포획 중에는 파괴되지 않도록 구현
* Pop 시 다시 일정 시간 뒤 파괴하도록 구현
* 포획된 아이템 이동 관련 Player와 Bubble 로직 수정